### PR TITLE
v1.0.0-beta.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A **TypeScript** type definitions package for `RegExp`.
     - `Escaped`
     - `EscapedArray`
     - `EscapedString`
+    - `EscapedStringFromArray`
     - `FromTo`
     - `NonCapturingRepetition`
     - `Quantifier`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@typedly/regexp",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@typedly/regexp",
-      "version": "1.0.0-beta.2",
+      "version": "1.0.0-beta.3",
       "funding": [
         {
           "type": "stripe",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typedly/regexp",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "author": "wwwdev.io <dev@wwwdev.io>",
   "description": "A TypeScript type definitions package for `RegExp`.",
   "license": "MIT",

--- a/src/lib/character/lib/character-range.type.ts
+++ b/src/lib/character/lib/character-range.type.ts
@@ -1,9 +1,14 @@
 // Type.
+import { EscapedStringFromArray } from "../../escaped-string-from-array.type";
 import { Escaped } from "../../escaped.type";
 import { FromTo } from "../../from-to.type";
 /**
  * @description
  * @export
+ * @template {string | number} [From='a'] 
+ * @template {string | number} [To='z'] 
+ * @template {string} [Character=''] 
+ * @template {boolean} [Negated=false] 
  * @example
  * const example1: CharacterRange<'a', 'z'>  = '[a-z]'; // "[a-z]"
  * const example2: CharacterRange<'', 'z'> = '[z]'; // "[z]"
@@ -11,14 +16,11 @@ import { FromTo } from "../../from-to.type";
  * const example4: CharacterRange<'', ''>  = '[]'; // "[]"
  * const example5: CharacterRange<'a', 'z', '_'> = '[a-z_]'; // "[a-z_]"
  * const example6: CharacterRange<'', '', '_'> = '[_]'; // "[_]"
- * @template {string | number} [From='a'] 
- * @template {string | number} [To='z'] 
- * @template {string} [Character=''] 
- * @template {boolean} [Negated=false] 
+ * const example7: CharacterRange<'a', 'z', ['d', 'w', 's']>  =  '[a-z\\d\\w\\s]'; // "[a-z\\d\\w\\s]"
  */
 export type CharacterRange<
   From extends string | number = 'a',
   To extends string | number = 'z',
-  Character extends string = '',
+  Character extends string | string[] = '',
   Negated extends boolean = false
-> = `[${FromTo<From, To, Negated, '-'>}${Escaped<Character>}]`;
+> = `[${FromTo<From, To, Negated, '-'>}${Character extends string ? Escaped<Character> : EscapedStringFromArray<Character>}]`;

--- a/src/lib/escaped-string-from-array.type.ts
+++ b/src/lib/escaped-string-from-array.type.ts
@@ -1,0 +1,15 @@
+// Type.
+import { EscapedString } from "./escaped-string.type";
+/**
+ * @description Converts `EscapeArray<Characters>` into a single escaped string.
+ * @export
+ * @template {string[]} Characters 
+ * @example
+ * type Test3 = EscapedStringFromArray<['d+', '*', 'W']>;
+ * // Expected: "\\d\\+\\*\\W"
+ * 
+ */
+export type EscapedStringFromArray<Characters extends string | string[]> =
+  Characters extends [infer First, ...infer Rest extends string[]]
+    ? `${EscapedString<First & string>}${EscapedStringFromArray<Rest>}`
+    : '';

--- a/src/lib/escaped.type.ts
+++ b/src/lib/escaped.type.ts
@@ -11,10 +11,9 @@ import { EscapedString } from "./escaped-string.type";
  * type TestArray = Escaped<['d+', '*', 'W']>;
  * // Expected: ["\\d\\+", "\\*", "\\W"]
  */
-export type Escaped<Character extends string | string[]> =
+export type Escaped<Character extends string | string[] = ''> =
   Character extends string
     ? EscapedString<Character>
     : Character extends string[]
     ? EscapedArray<Character>
     : never;
-    

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,6 +1,7 @@
 export type { Escaped } from './escaped.type';
 export type { EscapedArray } from './escaped-array.type';
 export type { EscapedString } from './escaped-string.type';
+export type { EscapedStringFromArray } from './escaped-string-from-array.type';
 export type { FromTo } from './from-to.type';
 export type { NonCapturingRepetition } from './non-capturing-repetition.type';
 export type { Quantifier } from './quantifier.type';

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -6,6 +6,7 @@ export type {
   Escaped,
   EscapedArray,
   EscapedString,
+  EscapedStringFromArray,
   FromTo,
   NonCapturingRepetition,
   Quantifier,


### PR DESCRIPTION
Add the `EscapedStringFromArray` 006068c5078929ea753a85a08ff85d4a0718b606
Include the `string[]` in the `CharacterRange` 39c9a75f0b9b98ece34b1b041c45f328c0f4854b
Defaults to an empty string in the `Escaped` 0ae6856e33dff403d5953ef14f86b1eab291a8e2
