### PR TITLE
v1.0.0-beta.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@typedly/regexp",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@typedly/regexp",
-      "version": "1.0.0-beta.3",
+      "version": "1.0.0-beta.4",
       "funding": [
         {
           "type": "stripe",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typedly/regexp",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "author": "wwwdev.io <dev@wwwdev.io>",
   "description": "A TypeScript type definitions package for `RegExp`.",
   "license": "MIT",

--- a/src/lib/escaped.type.ts
+++ b/src/lib/escaped.type.ts
@@ -1,19 +1,17 @@
 // Type.
-import { EscapedArray } from "./escaped-array.type";
+import { EscapedStringFromArray } from "./escaped-string-from-array.type";
 import { EscapedString } from "./escaped-string.type";
 /**
  * @description Escapes special characters in either a `string` or an `array` of strings.
  * @export
  * @template {string | string[]} Character 
  * @example
- * type TestString = Escaped<'d+*'>; 
- * // Expected: "\\d\\+\\*"
- * type TestArray = Escaped<['d+', '*', 'W']>;
- * // Expected: ["\\d\\+", "\\*", "\\W"]
+ * type TestString = Escaped<'d+*'>;  // Expected: "\\d\\+\\*"
+ * type TestArray = Escaped<['d+', '*', 'W']>; // Expected: "\\d\\+\\*\\W"
  */
 export type Escaped<Character extends string | string[] = ''> =
   Character extends string
     ? EscapedString<Character>
     : Character extends string[]
-    ? EscapedArray<Character>
+    ? EscapedStringFromArray<Character>
     : never;


### PR DESCRIPTION
Fixes `Escaped` by using the `EscapedStringFromArray` to return the `string` instead of `array`. 50c5672ded53f0cc901abe398043076534989db8
